### PR TITLE
Feature: Allow flasked config to accept map_data directly.

### DIFF
--- a/lib/flasked/board.ex
+++ b/lib/flasked/board.ex
@@ -4,8 +4,13 @@ defmodule Flasked.Board do
   alias Flasked.Config
 
   def mapping do
-    {data, _bindings} = Code.eval_file(otp_app_map_file_path)
-    data
+    case Config.map_data do
+      nil ->
+        {data, _bindings} = Code.eval_file(otp_app_map_file_path)
+        data
+      data ->
+        data
+    end
   end
 
   defp otp_app_map_file_path do

--- a/lib/flasked/config.ex
+++ b/lib/flasked/config.ex
@@ -3,15 +3,17 @@ defmodule Flasked.Config do
 
   def check do
     unless keys_present? do
-      raise(ArgumentError, message: "Missing :otp_app and/or :map_file in :flasked configuration")
+      raise(ArgumentError, message: ":otp_app and :map_file or :map_data are required in :flasked configuration")
     end
   end
 
   defp keys_present? do
     flasked_env = Application.get_all_env(:flasked)
-    Dict.has_key?(flasked_env, :otp_app) && Dict.has_key?(flasked_env, :map_file)
+    Dict.has_key?(flasked_env, :otp_app) && \
+      (Dict.has_key?(flasked_env, :map_data) || Dict.has_key?(flasked_env, :map_file))
   end
 
   def otp_app, do: Application.get_env(:flasked, :otp_app)
+  def map_data, do: Application.get_env(:flasked, :map_data)
   def map_file, do: Application.get_env(:flasked, :map_file)
 end


### PR DESCRIPTION
This PR allows `:flasked` config to accept `:map_data` directly, instead of loading from a `:map_file` at runtime.

If present, the `:map_data` config will override the `:map_file` config, and make it unnecessary.

The primary use case for this is in `escript`s, which cannot load files from the `priv` directory at runtime.